### PR TITLE
Make README commands specifically call python3

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -87,9 +87,12 @@ This will create two symbolic links to the interpreter `dots/` and the libs `lib
     cd AsciidotsDebugger
     
 Windows:
+
     set-asciidots-dir.cmd ../asciidots 
 
+
 Linux/Mac:
+
     chmod +x set-asciidots-dir.sh
     ./set-asciidots-dir.sh ../asciidots
 

--- a/readme.md
+++ b/readme.md
@@ -85,8 +85,14 @@ You need to tell where asciidot is installed (replace `../asciidots`  if it is n
 This will create two symbolic links to the interpreter `dots/` and the libs `libs/`.
 
     cd AsciidotsDebugger
-    set-asciidots-dir ../asciidots 
     
+Windows:
+    set-asciidots-dir.cmd ../asciidots 
+
+Linux/Mac:
+    chmod +x set-asciidots-dir.sh
+    ./set-asciidots-dir.sh ../asciidots
+
 Try it ! You can find more examples of Asciidots programs in the official repo along with the documentation of the language.
     
     python debugger.py samples/primes.dots


### PR DESCRIPTION
Most systems bind `python` to python 2 by default (instead of the python 3 that you want)