### PR TITLE
make --retina flag an actual flag

### DIFF
--- a/debugger.py
+++ b/debugger.py
@@ -66,7 +66,7 @@ class CallbacksRelay(IOCallbacksStorage):
 
 @click.command()
 @click.argument('filename')
-@click.option('--retina', default=False)
+@click.option('--retina', is_flag=True, default=False)
 def main(filename, retina):
     try:
         env = Env()


### PR DESCRIPTION
I just added `is_flag=True` to the `@click` decorator.

It no longer requires an argument after it (i.e. `--retina 1`)

Thanks for the great debugger!